### PR TITLE
Add support for configurable Redis options

### DIFF
--- a/module/config/modules/all.js
+++ b/module/config/modules/all.js
@@ -7,6 +7,7 @@ module.exports = async function (app, env, moduleOptions) {
     }
     app.module.use(redis_1.RedisModule.for({
         connection: moduleOptions.connection,
+        opts: moduleOptions.redisOpts,
         scripts: [{ name: "slidingWindow", path: __dirname + "../../../lua/slidingWindow.lua", args: 1 }]
     }));
 };

--- a/module/config/modules/all.ts
+++ b/module/config/modules/all.ts
@@ -13,6 +13,7 @@ export = async function (app: App, env: IEnv, moduleOptions: IOptions) {
     }
 
     app.module.use(RedisModule.for({
+        ...(moduleOptions.redisOptions || {}),
         connection: moduleOptions.connection,
         scripts: [{name: "slidingWindow", path: __dirname + "../../../lua/slidingWindow.lua", args: 1}]
     }));

--- a/module/src/common/IOptions.ts
+++ b/module/src/common/IOptions.ts
@@ -1,10 +1,13 @@
 
+import {IOptions as IRedisOptions} from "@appolo/redis";
+
 export interface IOptions  {
     id?: string
     connection?: string;
     keyPrefix?: string;
     maxBuckets?: number
     minBucketInterval?: number
+    redisOptions?: IRedisOptions
 }
 
 


### PR DESCRIPTION
Introduced `redisOptions` in the module configuration to allow customizable Redis parameters. Updated related TypeScript definitions and module initialization to support these new options. This enhances flexibility for Redis integration.